### PR TITLE
[bugfix] Due to documentation …

### DIFF
--- a/project-code/app/com/edulify/modules/geolocation/GeolocationPlugin.java
+++ b/project-code/app/com/edulify/modules/geolocation/GeolocationPlugin.java
@@ -12,7 +12,7 @@ public class GeolocationPlugin extends play.Plugin {
   public void onStart() {
     super.onStart();
     try {
-      Class<?> providerClass = Class.forName(Config.getStringOr("geolocation.provider", ""));
+      Class<?> providerClass = Class.forName(Config.getStringOr("geolocation.provider", "com.edulify.modules.geolocation.providers.FreegeoipProvider"));
       play.Logger.info("Starting GeolocationPlugin with provider " + providerClass);
       GeolocationProvider provider = (GeolocationProvider) providerClass.newInstance();
       AsyncGeolocationService.initialize(provider);

--- a/project-code/app/com/edulify/modules/geolocation/GeolocationPlugin.java
+++ b/project-code/app/com/edulify/modules/geolocation/GeolocationPlugin.java
@@ -1,5 +1,6 @@
 package com.edulify.modules.geolocation;
 
+import com.edulify.modules.geolocation.providers.FreegeoipProvider;
 import play.Application;
 
 public class GeolocationPlugin extends play.Plugin {
@@ -12,7 +13,7 @@ public class GeolocationPlugin extends play.Plugin {
   public void onStart() {
     super.onStart();
     try {
-      Class<?> providerClass = Class.forName(Config.getStringOr("geolocation.provider", "com.edulify.modules.geolocation.providers.FreegeoipProvider"));
+      Class<?> providerClass = Class.forName(Config.getStringOr("geolocation.provider", FreegeoipProvider.class.getCanonicalName()));
       play.Logger.info("Starting GeolocationPlugin with provider " + providerClass);
       GeolocationProvider provider = (GeolocationProvider) providerClass.newInstance();
       AsyncGeolocationService.initialize(provider);

--- a/project-code/conf/application.conf
+++ b/project-code/conf/application.conf
@@ -1,5 +1,5 @@
 geolocation {
-  provider = "com.edulify.modules.geolocation.AsyncGeolocationService"
+  provider = "com.edulify.modules.geolocation.providers.FreegeoipProvider"
   cache {
     on = true
     ttl = 100

--- a/project-code/test/com/edulify/modules/geolocation/GeolocationPluginTest.java
+++ b/project-code/test/com/edulify/modules/geolocation/GeolocationPluginTest.java
@@ -1,0 +1,33 @@
+package com.edulify.modules.geolocation;
+
+import org.junit.Test;
+import play.api.test.FakeApplication;
+import play.test.WithApplication;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static play.test.Helpers.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+/**
+ * Created by sovaalexandr
+ */
+public class GeolocationPluginTest extends WithApplication {
+
+  @Test
+  public void testOnStart() throws Exception {
+    Map<String, Object> config = new HashMap<>(0);
+    List<String> plugins = new ArrayList<>(1);
+    plugins.add(GeolocationPlugin.class.getCanonicalName());
+    running(fakeApplication(config, plugins), new Runnable() {
+      @Override
+      public void run() {
+        assertThat(app.getWrappedApplication(), instanceOf(FakeApplication.class));
+      }
+    });
+  }
+}


### PR DESCRIPTION
Due to documentation GeolocationPlugin could run without any additional configuration (with default options)

AR: While run plugin without additional configuration got RuntimeException with "Could not initialize GeolocationPlugin. Check if class configured in geolocation.provider exists" exception message
ER: Plugin starts with FreegeoipProvider